### PR TITLE
[FIX] 온보딩 프로필 설정 화면 UI 및 로직 수정

### DIFF
--- a/app/src/main/java/org/android/bbangzip/presentation/common/component/bottomsheet/ProfileImgPickerBottomSheet.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/common/component/bottomsheet/ProfileImgPickerBottomSheet.kt
@@ -56,6 +56,7 @@ fun ProfileImgPickerBottomSheet(
     onCancelClick: () -> Unit,
     onCompleteClick: () -> Unit,
     selectedImgResId: Int,
+    isCompleteBtnEnabled: Boolean = true,
 ) {
     BbangZipBottomSheetSlot(
         isBottomSheetVisible = isBottomSheetVisible,
@@ -125,6 +126,7 @@ fun ProfileImgPickerBottomSheet(
                 confirmButtonLabel = confirmButtonLabel,
                 onCancelClick = onCancelClick,
                 onCompleteClick = onCompleteClick,
+                isCompleteBtnEnabled = isCompleteBtnEnabled,
             )
 
             Gap(height = 27.dp)
@@ -136,6 +138,7 @@ fun ProfileImgPickerBottomSheet(
 private fun ProfileImgPickerBtn(
     confirmButtonLabel: String,
     modifier: Modifier = Modifier,
+    isCompleteBtnEnabled: Boolean = true,
     onCancelClick: () -> Unit,
     onCompleteClick: () -> Unit,
 ) {
@@ -165,6 +168,7 @@ private fun ProfileImgPickerBtn(
         BbangzipBaseButton(
             modifier = Modifier.weight(1f),
             onClick = onCompleteClick,
+            enabled = isCompleteBtnEnabled,
             trailingIcon = {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_check_default_24),
@@ -175,6 +179,8 @@ private fun ProfileImgPickerBtn(
             colors =
                 BbangZipButtonDefaults.colors(
                     enabledContainerColor = BbangZipTheme.color.primaryStrong_4B4137,
+                    disabledContainerColor = BbangZipTheme.color.labelDisable_E4E2E0,
+                    disabledContentColor = BbangZipTheme.color.labelAssistive_C9C7C5,
                 ),
             content = {
                 Text(

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingContract.kt
@@ -12,8 +12,8 @@ class OnboardingContract {
         val isNicknameValid: Boolean = false,
         val isNicknameBottomSheetVisible: Boolean = false,
         val isSaveBtnEnabled: Boolean = false,
-        val profileImg: Int = R.drawable.ic_profile_default_100,
-        val selectedImg: Int = R.drawable.ic_profile_default_100,
+        val profileImg: Int? = null,
+        val selectedImg: Int? = null,
         val isProfileImgBottomSheetVisible: Boolean = false,
         val onboardingState: Boolean = false,
     ) : BaseContract.State, Parcelable {
@@ -57,7 +57,7 @@ class OnboardingContract {
 
         data class UpdateCurrentProfileImg(val imgResId: Int) : OnboardingReduce
 
-        data class UpdateSelectedProfileImg(val imgResId: Int) : OnboardingReduce
+        data class UpdateSelectedProfileImg(val imgResId: Int?) : OnboardingReduce
     }
 
     sealed interface OnboardingSideEffect : BaseContract.SideEffect {

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingContract.kt
@@ -2,7 +2,6 @@ package org.android.bbangzip.presentation.ui.onboarding
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
-import org.android.bbangzip.R
 import org.android.bbangzip.presentation.common.base.BaseContract
 
 class OnboardingContract {

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
@@ -36,13 +36,13 @@ import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileNic
 import org.android.bbangzip.presentation.common.component.button.BbangZipButtonDefaults
 import org.android.bbangzip.presentation.common.component.button.BbangzipBaseButton
 import org.android.bbangzip.presentation.common.component.topbar.BbangZipBaseTopBar
+import org.android.bbangzip.presentation.common.util.constant.OnboardingConstants.DEFAULT_PROFILE_IMG_RES_ID
 import org.android.bbangzip.presentation.common.util.extension.Gap
 import org.android.bbangzip.presentation.common.util.extension.noRippleClickable
 import org.android.bbangzip.ui.theme.BBANGZIPANDROIDTheme
 import org.android.bbangzip.ui.theme.BbangZipTheme
 import org.android.bbangzip.ui.theme.defaultBbangZipColor
 import org.android.bbangzip.ui.theme.defaultBbangZipTypography
-import org.android.bbangzip.presentation.common.util.constant.OnboardingConstants.DEFAULT_PROFILE_IMG_RES_ID
 
 @Composable
 fun OnboardingScreen(

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
@@ -102,9 +102,9 @@ fun OnboardingScreen(
             onClick = onClickSaveBtn,
             trailingIcon = {
                 Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_x_default_24),
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_check_default_24),
                     contentDescription = null,
-                    modifier = Modifier.size(16.dp),
+                    modifier = Modifier.size(20.dp),
                 )
             },
             colors =

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
@@ -42,6 +42,7 @@ import org.android.bbangzip.ui.theme.BBANGZIPANDROIDTheme
 import org.android.bbangzip.ui.theme.BbangZipTheme
 import org.android.bbangzip.ui.theme.defaultBbangZipColor
 import org.android.bbangzip.ui.theme.defaultBbangZipTypography
+import org.android.bbangzip.presentation.common.util.constant.OnboardingConstants.DEFAULT_PROFILE_IMG_RES_ID
 
 @Composable
 fun OnboardingScreen(
@@ -79,7 +80,7 @@ fun OnboardingScreen(
         Gap(height = 32.dp)
 
         ProfileImageArea(
-            currentProfileResId = state.profileImg,
+            currentProfileResId = state.profileImg ?: DEFAULT_PROFILE_IMG_RES_ID,
             onClick = onClickProfileImg,
         )
 
@@ -141,7 +142,8 @@ fun OnboardingScreen(
         onProfileImgItemClick = onSelectProfileImg,
         onCancelClick = onClickProfileImgCancelBtn,
         onCompleteClick = onClickProfileImgCompleteBtn,
-        selectedImgResId = state.selectedImg,
+        selectedImgResId = state.selectedImg ?: DEFAULT_PROFILE_IMG_RES_ID,
+        isCompleteBtnEnabled = state.selectedImg != null,
     )
 }
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -95,7 +95,6 @@ class OnboardingViewModel
             refreshSaveButtonState()
         }
 
-
         override fun reduceState(
             state: OnboardingContract.OnboardingState,
             reduce: OnboardingContract.OnboardingReduce,

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -44,24 +44,18 @@ class OnboardingViewModel
 
                 OnboardingContract.OnboardingEvent.OnClickNicknameBottomSheetDismissRequest -> {
                     updateState(OnboardingContract.OnboardingReduce.UpdateNicknameBottomSheetVisibility(isVisible = false))
+                    refreshSaveButtonState()
                 }
 
                 OnboardingContract.OnboardingEvent.OnNicknameInputDone -> {
-                    val finalNickname = currentUiState.nickname
-
-                    if (finalNickname.isNotEmpty()) {
-                        updateState(OnboardingContract.OnboardingReduce.UpdateSaveButtonEnabled(true))
-                    } else {
-                        updateState(OnboardingContract.OnboardingReduce.UpdateSaveButtonEnabled(false))
-                    }
-
                     updateState(OnboardingContract.OnboardingReduce.UpdateNicknameBottomSheetVisibility(isVisible = false))
+                    refreshSaveButtonState()
                 }
 
                 // 프로필 이미지
                 OnboardingContract.OnboardingEvent.OnClickProfileImgSettingBtn -> {
                     updateState(OnboardingContract.OnboardingReduce.UpdateProfileImgBottomSheetVisibility(true))
-                    updateState(OnboardingContract.OnboardingReduce.UpdateSelectedProfileImg(currentUiState.profileImg))
+                    currentUiState.profileImg?.let { updateState(OnboardingContract.OnboardingReduce.UpdateSelectedProfileImg(it)) }
                 }
 
                 is OnboardingContract.OnboardingEvent.OnSelectProfileImg -> {
@@ -74,23 +68,33 @@ class OnboardingViewModel
                 }
 
                 OnboardingContract.OnboardingEvent.OnClickProfileImgBottomSheetDismissRequest -> {
-                    updateState(OnboardingContract.OnboardingReduce.UpdateProfileImgBottomSheetVisibility(isVisible = false))
-                    updateState(OnboardingContract.OnboardingReduce.UpdateSelectedProfileImg(currentUiState.profileImg))
+                    applySelectedProfileImgAndDismiss()
                 }
 
                 OnboardingContract.OnboardingEvent.OnClickProfileImgCompleteBtn -> {
-                    updateState(OnboardingContract.OnboardingReduce.UpdateProfileImgBottomSheetVisibility(isVisible = false))
-                    updateState(OnboardingContract.OnboardingReduce.UpdateCurrentProfileImg(currentUiState.selectedImg))
+                    applySelectedProfileImgAndDismiss()
                 }
 
                 // 온보딩 완료
                 OnboardingContract.OnboardingEvent.OnClickSaveBtn -> {
                     if (currentUiState.isSaveBtnEnabled) {
-                        signup(currentUiState.nickname, currentUiState.profileImg)
+                        signup(currentUiState.nickname, currentUiState.profileImg ?: 0)
                     }
                 }
             }
         }
+
+        private fun refreshSaveButtonState() {
+            val isEnabled = currentUiState.nickname.isNotEmpty() && currentUiState.profileImg != null
+            updateState(OnboardingContract.OnboardingReduce.UpdateSaveButtonEnabled(isEnabled))
+        }
+
+        private fun applySelectedProfileImgAndDismiss() {
+            updateState(OnboardingContract.OnboardingReduce.UpdateProfileImgBottomSheetVisibility(isVisible = false))
+            currentUiState.selectedImg?.let { updateState(OnboardingContract.OnboardingReduce.UpdateCurrentProfileImg(it)) }
+            refreshSaveButtonState()
+        }
+
 
         override fun reduceState(
             state: OnboardingContract.OnboardingState,
@@ -132,7 +136,7 @@ class OnboardingViewModel
 
         private fun signup(
             nickname: String,
-            profileImgKey: Int = 0,
+            profileImgKey: Int,
         ) {
             viewModelScope.launch {
                 userRepository.onboardingComplete(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="profile_img_picker_title">프로필 이미지 설정</string>
 
     <!-- Profile Nickname BottomSheet -->
-    <string name="profile_nickname_input_title">이름 설정하기</string>
+    <string name="profile_nickname_input_title">이름 설정</string>
 
     <!-- timer - view -->
     <string name="timer_idle_title">오늘의 빵을 구워보세요!</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #67 

## Work Description ✏️
- [x] 온보딩 프로필 설정 화면에서 프로필을 설정하지 않았을 때 저장하기 버튼이 비활성화 되도록 수정
- [x] 저장하기 버튼의 아이콘 ic_check 로 변경
- [x] 닉네임 설정 바텀시트의 title "이름 수정"으로 변경
- [x] 프로필 이미지 설정 바텀시트 dismiss request 시 완료 버튼을 누른것과 동일한 로직 구현
- [x] 닉네임 설정 바텀시트 dismiss request 시에도 저장 버튼 활성화 체크하도록 구  

## Screenshot 📸

https://github.com/user-attachments/assets/aec5c2b4-641a-425d-8323-847d5097e72b

## To Reviewers 📢
no reviewer