### PR TITLE
[Feat] UX 개선을 위한 디자인 변경사항 구현

### DIFF
--- a/app/src/main/java/org/android/bbangzip/data/datasource/remote/dto/response/ResponseProfileInformationDto.kt
+++ b/app/src/main/java/org/android/bbangzip/data/datasource/remote/dto/response/ResponseProfileInformationDto.kt
@@ -8,6 +8,8 @@ import org.android.bbangzip.domain.model.ProfileInformation
 data class ResponseProfileInformationDto(
     @SerialName("profileImageUrl")
     val profileImageUrl: String,
+    @SerialName("profileImageKey")
+    val profileImageKey: Int,
     @SerialName("nickname")
     val nickname: String,
     @SerialName("commitmentMessage")
@@ -16,6 +18,7 @@ data class ResponseProfileInformationDto(
     fun toProfileInformation() =
         ProfileInformation(
             profileImageUrl = profileImageUrl,
+            profileImageKey = profileImageKey,
             nickname = nickname,
             commitmentMessage = commitmentMessage,
         )

--- a/app/src/main/java/org/android/bbangzip/domain/model/ProfileInformation.kt
+++ b/app/src/main/java/org/android/bbangzip/domain/model/ProfileInformation.kt
@@ -2,6 +2,7 @@ package org.android.bbangzip.domain.model
 
 data class ProfileInformation(
     val profileImageUrl: String,
+    val profileImageKey: Int,
     val nickname: String,
     val commitmentMessage: String,
 )

--- a/app/src/main/java/org/android/bbangzip/presentation/common/component/bottomsheet/TimePickerBottomSheet.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/common/component/bottomsheet/TimePickerBottomSheet.kt
@@ -1,5 +1,6 @@
 package org.android.bbangzip.presentation.common.component.bottomsheet
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -28,6 +30,7 @@ import org.android.bbangzip.presentation.common.component.button.BbangZipButtonD
 import org.android.bbangzip.presentation.common.component.button.BbangzipBaseButton
 import org.android.bbangzip.presentation.common.component.timepicker.BbangZipTimePicker
 import org.android.bbangzip.presentation.common.util.extension.Gap
+import org.android.bbangzip.presentation.common.util.extension.noRippleClickable
 import org.android.bbangzip.ui.theme.BBANGZIPANDROIDTheme
 import org.android.bbangzip.ui.theme.BbangZipTheme
 import java.time.LocalTime
@@ -39,6 +42,7 @@ fun TimePickerBottomSheet(
     onDismissRequest: () -> Unit,
     onCancleButtonClick: () -> Unit,
     onConfirmButtonClick: (LocalTime) -> Unit,
+    onClearButtonClick: () -> Unit,
     initialTime: LocalTime,
 ) {
     var selectedTime by remember(initialTime) { mutableStateOf(initialTime) }
@@ -47,10 +51,8 @@ fun TimePickerBottomSheet(
         isBottomSheetVisible = isBottomSheetVisible,
         onDismissRequest = onDismissRequest,
         title = {
-            Text(
-                text = stringResource(R.string.time_picker_title),
-                color = BbangZipTheme.color.labelAlternative_A29D96,
-                style = BbangZipTheme.typography.title3SemiBold,
+            TimePickerBottomSheetTitle(
+                onClearButtonClick = onClearButtonClick
             )
         },
         content = {
@@ -115,10 +117,57 @@ fun TimePickerBottomSheet(
     )
 }
 
+@Composable
+fun TimePickerBottomSheetTitle(
+    onClearButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth(),
+    ){
+        ClearTimeButton(
+            modifier = Modifier.align(Alignment.CenterStart),
+            onClick = onClearButtonClick
+        )
+
+        Text(
+            text = stringResource(R.string.time_picker_title),
+            color = BbangZipTheme.color.labelAlternative_A29D96,
+            style = BbangZipTheme.typography.title3SemiBold,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}
+
+@Composable
+private fun ClearTimeButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.noRippleClickable{ onClick() },
+        verticalAlignment = Alignment.CenterVertically,
+    ){
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_return_default_24),
+            contentDescription = null,
+            tint = BbangZipTheme.color.todoRed2_F09C86,
+            modifier = Modifier.size(20.dp)
+        )
+
+        Text(
+            text = "초기화",
+            style = BbangZipTheme.typography.label2Regular,
+            color = BbangZipTheme.color.todoRed2_F09C86,
+        )
+    }
+}
+
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun TimePickerBottomSheetPreview() {
-    var isBottomSheetVisible by remember { mutableStateOf(false) }
+    var isBottomSheetVisible by remember { mutableStateOf(true) }
 
     BBANGZIPANDROIDTheme {
         Column(
@@ -144,6 +193,7 @@ fun TimePickerBottomSheetPreview() {
                 onDismissRequest = { isBottomSheetVisible = !isBottomSheetVisible },
                 onCancleButtonClick = {},
                 onConfirmButtonClick = {},
+                onClearButtonClick = {},
                 initialTime = LocalTime.now(),
             )
         }

--- a/app/src/main/java/org/android/bbangzip/presentation/common/component/textfield/BbangZipTextFieldSlot.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/common/component/textfield/BbangZipTextFieldSlot.kt
@@ -34,7 +34,7 @@ fun BbangZipTextFieldSlot(
             trailingIcon()
         }
         guideline()
-        characterCount()
         underLine()
+        characterCount()
     }
 }

--- a/app/src/main/java/org/android/bbangzip/presentation/common/component/textfield/BbangZipUnderLinedTextField.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/common/component/textfield/BbangZipUnderLinedTextField.kt
@@ -40,6 +40,7 @@ fun BbangZipUnderLinedTextField(
     leadingIcon: @Composable (() -> Unit)? = null,
     @StringRes placeholder: Int? = null,
     @StringRes guideline: Int? = null,
+    maxCharacter: Int = 20,
     textStyles: TextFieldTypography = BbangZipUnderlinedTextFieldDefaults.typography(),
     colors: TextFieldColors = BbangZipUnderlinedTextFieldDefaults.colors(),
     contentPadding: PaddingValues = BbangZipUnderlinedTextFieldDefaults.CONTENT_PADDING,
@@ -74,6 +75,7 @@ fun BbangZipUnderLinedTextField(
         contentPadding = contentPadding,
         isUnderLined = isUnderLined,
         maxLines = 1,
+        maxCharacter = maxCharacter,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
     )

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingContract.kt
@@ -8,7 +8,6 @@ class OnboardingContract {
     @Parcelize
     data class OnboardingState(
         val nickname: String = "",
-        val isNicknameValid: Boolean = false,
         val isNicknameBottomSheetVisible: Boolean = false,
         val isSaveBtnEnabled: Boolean = false,
         val profileImg: Int? = null,
@@ -22,11 +21,7 @@ class OnboardingContract {
     sealed interface OnboardingEvent : BaseContract.Event {
         data object OnClickPreviousBtn : OnboardingEvent
 
-        data object OnClickNicknameTextField : OnboardingEvent
-
         data class OnChangeNickname(val input: String) : OnboardingEvent
-
-        data object OnClickNicknameBottomSheetDismissRequest : OnboardingEvent
 
         data object OnNicknameInputDone : OnboardingEvent
 
@@ -65,7 +60,5 @@ class OnboardingContract {
         data object NavigateToLogin : OnboardingSideEffect
 
         data object DismissProfileImgBottomSheet : OnboardingSideEffect
-
-        data object DismissNicknameInputBottomSheet : OnboardingSideEffect
     }
 }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingRoute.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingRoute.kt
@@ -20,7 +20,6 @@ fun OnboardingRoute(
             when (effect) {
                 OnboardingContract.OnboardingSideEffect.NavigateToTimer -> navigateToTimer()
                 OnboardingContract.OnboardingSideEffect.NavigateToLogin -> navigateToLogin()
-                OnboardingContract.OnboardingSideEffect.DismissNicknameInputBottomSheet -> viewModel.setEvent(OnboardingContract.OnboardingEvent.OnClickNicknameBottomSheetDismissRequest)
                 OnboardingContract.OnboardingSideEffect.DismissProfileImgBottomSheet -> viewModel.setEvent(OnboardingContract.OnboardingEvent.OnClickProfileImgBottomSheetDismissRequest)
             }
         }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingRoute.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingRoute.kt
@@ -29,9 +29,6 @@ fun OnboardingRoute(
     OnboardingScreen(
         state = state,
         onNicknameChange = { viewModel.setEvent(OnboardingContract.OnboardingEvent.OnChangeNickname(it)) },
-        onClickNicknameTextField = { viewModel.setEvent(OnboardingContract.OnboardingEvent.OnClickNicknameTextField) },
-        onClickNicknameInputBottomSheetDismissRequest = { viewModel.setEvent(OnboardingContract.OnboardingEvent.OnClickNicknameBottomSheetDismissRequest) },
-        onNicknameInputDoneAction = { viewModel.setEvent(OnboardingContract.OnboardingEvent.OnNicknameInputDone) },
         onClickProfileImg = { viewModel.setEvent(OnboardingContract.OnboardingEvent.OnClickProfileImgSettingBtn) },
         onSelectProfileImg = { viewModel.setEvent(OnboardingContract.OnboardingEvent.OnSelectProfileImg(it)) },
         onClickProfileImgBottomSheetDismissRequest = { viewModel.setEvent(OnboardingContract.OnboardingEvent.OnClickProfileImgBottomSheetDismissRequest) },

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
@@ -19,9 +19,11 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
@@ -32,9 +34,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.android.bbangzip.R
 import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileImgPickerBottomSheet
-import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileNicknameInputBottomSheet
 import org.android.bbangzip.presentation.common.component.button.BbangZipButtonDefaults
 import org.android.bbangzip.presentation.common.component.button.BbangzipBaseButton
+import org.android.bbangzip.presentation.common.component.textfield.BbangZipUnderLinedTextField
 import org.android.bbangzip.presentation.common.component.topbar.BbangZipBaseTopBar
 import org.android.bbangzip.presentation.common.util.constant.OnboardingConstants.DEFAULT_PROFILE_IMG_RES_ID
 import org.android.bbangzip.presentation.common.util.extension.Gap
@@ -48,9 +50,6 @@ import org.android.bbangzip.ui.theme.defaultBbangZipTypography
 fun OnboardingScreen(
     state: OnboardingContract.OnboardingState,
     onNicknameChange: (String) -> Unit = {},
-    onClickNicknameTextField: () -> Unit = {},
-    onClickNicknameInputBottomSheetDismissRequest: () -> Unit = {},
-    onNicknameInputDoneAction: () -> Unit = {},
     onClickProfileImg: () -> Unit = {},
     onSelectProfileImg: (Int) -> Unit = {},
     onClickProfileImgBottomSheetDismissRequest: () -> Unit = {},
@@ -60,6 +59,7 @@ fun OnboardingScreen(
     onClickSaveBtn: () -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
+    val focusRequester = remember { FocusRequester() }
 
     Column(
         modifier =
@@ -86,9 +86,12 @@ fun OnboardingScreen(
 
         Gap(height = 48.dp)
 
-        NicknameClickableField(
+        BbangZipUnderLinedTextField(
+            modifier = Modifier.padding(horizontal = 20.dp),
             value = state.nickname,
-            onClick = onClickNicknameTextField,
+            onValueChange = onNicknameChange,
+            focusManager = focusManager,
+            focusRequester = focusRequester,
             placeholder = R.string.onboarding_name_description,
         )
 
@@ -123,18 +126,6 @@ fun OnboardingScreen(
             },
         )
     }
-
-    ProfileNicknameInputBottomSheet(
-        isBottomSheetVisible = state.isNicknameBottomSheetVisible,
-        onDismissRequest = onClickNicknameInputBottomSheetDismissRequest,
-        nickname = state.nickname,
-        focusManager = focusManager,
-        onNicknameChange = onNicknameChange,
-        onDoneAction = {
-            focusManager.clearFocus()
-            onNicknameInputDoneAction()
-        },
-    )
 
     ProfileImgPickerBottomSheet(
         isBottomSheetVisible = state.isProfileImgBottomSheetVisible,

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingScreen.kt
@@ -1,7 +1,6 @@
 package org.android.bbangzip.presentation.ui.onboarding
 
 import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,7 +42,6 @@ import org.android.bbangzip.presentation.common.util.extension.noRippleClickable
 import org.android.bbangzip.ui.theme.BBANGZIPANDROIDTheme
 import org.android.bbangzip.ui.theme.BbangZipTheme
 import org.android.bbangzip.ui.theme.defaultBbangZipColor
-import org.android.bbangzip.ui.theme.defaultBbangZipTypography
 
 @Composable
 fun OnboardingScreen(
@@ -168,50 +165,6 @@ private fun ProfileImageArea(
                 Modifier
                     .size(24.dp)
                     .align(Alignment.BottomEnd),
-        )
-    }
-}
-
-@Composable
-private fun NicknameClickableField(
-    value: String,
-    onClick: () -> Unit,
-    @StringRes placeholder: Int,
-    modifier: Modifier = Modifier,
-) {
-    val textColor =
-        if (value.isEmpty()) {
-            defaultBbangZipColor.labelAssistive_C9C7C5
-        } else {
-            defaultBbangZipColor.labelNormal_6B6560
-        }
-
-    val textToShow =
-        if (value.isEmpty()) {
-            stringResource(placeholder)
-        } else {
-            value
-        }
-
-    Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .noRippleClickable(onClick = onClick),
-    ) {
-        Text(
-            text = textToShow,
-            style = defaultBbangZipTypography.body1Medium,
-            color = textColor,
-            modifier = Modifier.padding(start = 2.dp),
-        )
-
-        Gap(height = 8.dp)
-
-        HorizontalDivider(
-            thickness = 2.dp,
-            color = defaultBbangZipColor.primaryNormal_897869,
         )
     }
 }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/onboarding/OnboardingViewModel.kt
@@ -33,18 +33,8 @@ class OnboardingViewModel
                     setSideEffect(OnboardingContract.OnboardingSideEffect.NavigateToLogin)
                 }
 
-                // 닉네임
-                OnboardingContract.OnboardingEvent.OnClickNicknameTextField -> {
-                    updateState(OnboardingContract.OnboardingReduce.UpdateNicknameBottomSheetVisibility(isVisible = true))
-                }
-
                 is OnboardingContract.OnboardingEvent.OnChangeNickname -> {
                     updateState(OnboardingContract.OnboardingReduce.UpdateNickname(event.input))
-                }
-
-                OnboardingContract.OnboardingEvent.OnClickNicknameBottomSheetDismissRequest -> {
-                    updateState(OnboardingContract.OnboardingReduce.UpdateNicknameBottomSheetVisibility(isVisible = false))
-                    refreshSaveButtonState(nickname = currentUiState.nickname, profileImg = currentUiState.profileImg)
                 }
 
                 OnboardingContract.OnboardingEvent.OnNicknameInputDone -> {

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditContract.kt
@@ -46,6 +46,8 @@ class ProfileEditContract {
         data class OnCommitmentMessageChange(val commitmentMessage: String) : ProfileEditEvent
 
         data object OnCommitmentBottomSheetDismissRequest : ProfileEditEvent
+
+        data object OnSaveButtonClick : ProfileEditEvent
     }
 
     sealed interface ProfileEditReduce : BaseContract.Reduce {

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditContract.kt
@@ -4,12 +4,13 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import org.android.bbangzip.R
 import org.android.bbangzip.presentation.common.base.BaseContract
+import org.android.bbangzip.presentation.common.util.constant.OnboardingConstants
 
 class ProfileEditContract {
     @Parcelize
     data class ProfileEditState(
-        val profileImg: Int = R.drawable.ic_profile_default_100,
-        val selectedImg: Int = R.drawable.ic_profile_default_100,
+        val profileImageResId: Int = R.drawable.ic_profile_default_100,
+        val selectedProfileImageKey: Int = 1,
         val isProfileImgBottomSheetVisible: Boolean = false,
         val nickname: String = "",
         val isNicknameBottomSheetVisible: Boolean = false,
@@ -17,6 +18,8 @@ class ProfileEditContract {
         val isCommitmentBottomSheetVisible: Boolean = false,
     ) : BaseContract.State, Parcelable {
         override fun toParcelable(): Parcelable = this
+
+        val selectedProfileImageResId get() = OnboardingConstants.PROFILE_IMG_RES_IDS[selectedProfileImageKey-1]
     }
 
     sealed interface ProfileEditEvent : BaseContract.Event {
@@ -30,7 +33,7 @@ class ProfileEditContract {
 
         data object OnCommitmentMessageClick : ProfileEditEvent
 
-        data class OnProfileImgSelect(val imgRes: Int) : ProfileEditEvent
+        data class OnProfileImageSelect(val imageRes: Int) : ProfileEditEvent
 
         data object OnProfileImgCompleteBtnClick : ProfileEditEvent
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditContract.kt
@@ -13,7 +13,6 @@ class ProfileEditContract {
         val selectedProfileImageKey: Int = 1,
         val isProfileImgBottomSheetVisible: Boolean = false,
         val nickname: String = "",
-        val isNicknameBottomSheetVisible: Boolean = false,
         val commitmentMessage: String = "",
         val isCommitmentBottomSheetVisible: Boolean = false,
     ) : BaseContract.State, Parcelable {
@@ -29,8 +28,6 @@ class ProfileEditContract {
 
         data object OnProfileImgClick : ProfileEditEvent
 
-        data object OnNicknameClick : ProfileEditEvent
-
         data object OnCommitmentMessageClick : ProfileEditEvent
 
         data class OnProfileImageSelect(val imageRes: Int) : ProfileEditEvent
@@ -40,8 +37,6 @@ class ProfileEditContract {
         data object OnProfileImgBottomSheetDismissRequest : ProfileEditEvent
 
         data class OnNicknameChange(val nickname: String) : ProfileEditEvent
-
-        data object OnNicknameBottomSheetDismissRequest : ProfileEditEvent
 
         data class OnCommitmentMessageChange(val commitmentMessage: String) : ProfileEditEvent
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditRoute.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditRoute.kt
@@ -48,8 +48,8 @@ fun ProfileEditRoute(
         onProfileImageBottomSheetDismissRequest = {
             viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnProfileImgBottomSheetDismissRequest)
         },
-        onSelectProfileImg = {
-            viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnProfileImgSelect(it))
+        onSelectProfileImage = {
+            viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnProfileImageSelect(it))
         },
         onProfileImageCancelBtnClick = {
             viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnProfileImgBottomSheetDismissRequest)

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditRoute.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditRoute.kt
@@ -33,17 +33,8 @@ fun ProfileEditRoute(
         onNicknameChange = {
             viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnNicknameChange(it))
         },
-        onNicknameClick = {
-            viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnNicknameClick)
-        },
         onCommitmentAreaClick = {
             viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnCommitmentMessageClick)
-        },
-        onNicknameInputBottomSheetDismissRequest = {
-            viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnNicknameBottomSheetDismissRequest)
-        },
-        onNicknameInputDoneAction = {
-            viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnNicknameBottomSheetDismissRequest)
         },
         onProfileImageBottomSheetDismissRequest = {
             viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnProfileImgBottomSheetDismissRequest)

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditRoute.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditRoute.kt
@@ -54,5 +54,8 @@ fun ProfileEditRoute(
         onCommitmentMessageChange = {
             viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnCommitmentMessageChange(it))
         },
+        onSaveButtonClick = {
+            viewModel.setEvent(ProfileEditContract.ProfileEditEvent.OnSaveButtonClick)
+        },
     )
 }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditScreen.kt
@@ -24,15 +24,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.android.bbangzip.R
 import org.android.bbangzip.presentation.common.component.bottomsheet.CommitmentBottomSheet
 import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileImgPickerBottomSheet
+import org.android.bbangzip.presentation.common.component.button.BbangZipButtonDefaults
+import org.android.bbangzip.presentation.common.component.button.BbangzipBaseButton
 import org.android.bbangzip.presentation.common.component.textfield.BbangZipUnderLinedTextField
 import org.android.bbangzip.presentation.common.component.topbar.BbangZipBaseTopBar
 import org.android.bbangzip.presentation.common.util.extension.Gap
@@ -53,6 +57,7 @@ fun ProfileEditScreen(
     onProfileImageCompleteBtnClick: () -> Unit = {},
     onCommitmentBottomSheetDismissRequest: () -> Unit = {},
     onCommitmentMessageChange: (String) -> Unit = {},
+    onSaveButtonClick: () -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
@@ -96,6 +101,36 @@ fun ProfileEditScreen(
         CommitmentMessageArea(
             commitmentMessage = state.commitmentMessage,
             onCommitmentAreaClick = onCommitmentAreaClick,
+        )
+
+        Gap()
+
+        BbangzipBaseButton(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+            onClick = onSaveButtonClick,
+            trailingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(R.drawable.ic_check_default_24),
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+            },
+            colors =
+                BbangZipButtonDefaults.colors(
+                    enabledContainerColor = BbangZipTheme.color.primaryStrong_4B4137,
+                    enabledContentColor = BbangZipTheme.color.staticWhite_FFFFFF,
+                    disabledContainerColor = BbangZipTheme.color.labelDisable_E4E2E0,
+                    disabledContentColor = BbangZipTheme.color.labelAssistive_C9C7C5,
+                ),
+            content = {
+                Text(
+                    text = stringResource(R.string.button_label_save),
+                    style = BbangZipTheme.typography.body2Medium,
+                )
+            },
         )
     }
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import org.android.bbangzip.R
 import org.android.bbangzip.presentation.common.component.bottomsheet.CommitmentBottomSheet
 import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileImgPickerBottomSheet
-import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileNicknameInputBottomSheet
 import org.android.bbangzip.presentation.common.component.textfield.BbangZipUnderLinedTextField
 import org.android.bbangzip.presentation.common.component.topbar.BbangZipBaseTopBar
 import org.android.bbangzip.presentation.common.util.extension.Gap
@@ -46,11 +45,8 @@ fun ProfileEditScreen(
     state: ProfileEditContract.ProfileEditState,
     onBackIconClick: () -> Unit = {},
     onProfileImageClick: () -> Unit = {},
-    onNicknameClick: () -> Unit = {},
     onCommitmentAreaClick: () -> Unit = {},
     onNicknameChange: (String) -> Unit = {},
-    onNicknameInputBottomSheetDismissRequest: () -> Unit = {},
-    onNicknameInputDoneAction: () -> Unit = {},
     onProfileImageBottomSheetDismissRequest: () -> Unit = {},
     onSelectProfileImage: (Int) -> Unit = {},
     onProfileImageCancelBtnClick: () -> Unit = {},
@@ -90,7 +86,7 @@ fun ProfileEditScreen(
 
         NicknameArea(
             nickname = state.nickname,
-            onNicknameClick = onNicknameClick,
+            onNicknameChange = onNicknameChange,
             focusManager = focusManager,
             focusRequester = focusRequester,
         )
@@ -111,18 +107,6 @@ fun ProfileEditScreen(
         onCancelClick = onProfileImageCancelBtnClick,
         onCompleteClick = onProfileImageCompleteBtnClick,
         selectedImgResId = state.selectedProfileImageResId,
-    )
-
-    ProfileNicknameInputBottomSheet(
-        isBottomSheetVisible = state.isNicknameBottomSheetVisible,
-        onDismissRequest = onNicknameInputBottomSheetDismissRequest,
-        nickname = state.nickname,
-        focusManager = focusManager,
-        onNicknameChange = onNicknameChange,
-        onDoneAction = {
-            focusManager.clearFocus()
-            onNicknameInputDoneAction()
-        },
     )
 
     CommitmentBottomSheet(
@@ -174,8 +158,8 @@ private fun NicknameArea(
     nickname: String,
     focusManager: FocusManager,
     focusRequester: FocusRequester,
+    onNicknameChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    onNicknameClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -194,7 +178,8 @@ private fun NicknameArea(
 
             BbangZipUnderLinedTextField(
                 value = nickname,
-                onValueChange = {i ->},
+                onValueChange = onNicknameChange,
+                placeholder = R.string.onboarding_name_description,
                 focusManager = focusManager,
                 focusRequester = focusRequester,
             )

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditScreen.kt
@@ -18,9 +18,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -31,6 +34,7 @@ import org.android.bbangzip.R
 import org.android.bbangzip.presentation.common.component.bottomsheet.CommitmentBottomSheet
 import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileImgPickerBottomSheet
 import org.android.bbangzip.presentation.common.component.bottomsheet.ProfileNicknameInputBottomSheet
+import org.android.bbangzip.presentation.common.component.textfield.BbangZipUnderLinedTextField
 import org.android.bbangzip.presentation.common.component.topbar.BbangZipBaseTopBar
 import org.android.bbangzip.presentation.common.util.extension.Gap
 import org.android.bbangzip.presentation.common.util.extension.noRippleClickable
@@ -48,13 +52,14 @@ fun ProfileEditScreen(
     onNicknameInputBottomSheetDismissRequest: () -> Unit = {},
     onNicknameInputDoneAction: () -> Unit = {},
     onProfileImageBottomSheetDismissRequest: () -> Unit = {},
-    onSelectProfileImg: (Int) -> Unit = {},
+    onSelectProfileImage: (Int) -> Unit = {},
     onProfileImageCancelBtnClick: () -> Unit = {},
     onProfileImageCompleteBtnClick: () -> Unit = {},
     onCommitmentBottomSheetDismissRequest: () -> Unit = {},
     onCommitmentMessageChange: (String) -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
+    val focusRequester = remember { FocusRequester() }
 
     Column(
         modifier =
@@ -77,7 +82,7 @@ fun ProfileEditScreen(
         Gap(height = 28.dp)
 
         ProfileImageArea(
-            currentProfileResId = state.profileImg,
+            currentProfileResId = state.profileImageResId,
             onClick = onProfileImageClick,
         )
 
@@ -86,6 +91,8 @@ fun ProfileEditScreen(
         NicknameArea(
             nickname = state.nickname,
             onNicknameClick = onNicknameClick,
+            focusManager = focusManager,
+            focusRequester = focusRequester,
         )
 
         Gap(height = 48.dp)
@@ -100,10 +107,10 @@ fun ProfileEditScreen(
         confirmButtonLabel = stringResource(R.string.button_label_save),
         isBottomSheetVisible = state.isProfileImgBottomSheetVisible,
         onDismissRequest = onProfileImageBottomSheetDismissRequest,
-        onProfileImgItemClick = onSelectProfileImg,
+        onProfileImgItemClick = onSelectProfileImage,
         onCancelClick = onProfileImageCancelBtnClick,
         onCompleteClick = onProfileImageCompleteBtnClick,
-        selectedImgResId = state.selectedImg,
+        selectedImgResId = state.selectedProfileImageResId,
     )
 
     ProfileNicknameInputBottomSheet(
@@ -165,47 +172,32 @@ private fun ProfileImageArea(
 @Composable
 private fun NicknameArea(
     nickname: String,
+    focusManager: FocusManager,
+    focusRequester: FocusRequester,
     modifier: Modifier = Modifier,
     onNicknameClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
     ) {
-        Row(
+        Column(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp),
-            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = stringResource(R.string.my_profile_edit_name),
             )
 
-            Gap()
+            Gap(height = 20.dp)
 
-            Row(
-                modifier =
-                    Modifier.noRippleClickable {
-                        onNicknameClick()
-                    },
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = nickname,
-                    style = BbangZipTheme.typography.body1Medium,
-                    color = BbangZipTheme.color.labelStrong_463D34,
-                )
-
-                Gap(width = 8.dp)
-
-                Icon(
-                    modifier = Modifier.padding(4.dp),
-                    painter = painterResource(R.drawable.ic_arrow_right_24),
-                    contentDescription = null,
-                    tint = BbangZipTheme.color.labelAlternative_A29D96,
-                )
-            }
+            BbangZipUnderLinedTextField(
+                value = nickname,
+                onValueChange = {i ->},
+                focusManager = focusManager,
+                focusRequester = focusRequester,
+            )
         }
     }
 }
@@ -274,7 +266,7 @@ fun ProfileEditScreenPreview() {
         ProfileEditScreen(
             state =
                 ProfileEditContract.ProfileEditState(
-                    profileImg = R.drawable.ic_profile_default_100,
+                    profileImageResId = R.drawable.ic_profile_default_100,
                     nickname = "김재민",
                     commitmentMessage = "빵을 굽자",
                 ),

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditViewModel.kt
@@ -88,6 +88,10 @@ class ProfileEditViewModel
                         ),
                     )
                 }
+
+                ProfileEditContract.ProfileEditEvent.OnSaveButtonClick -> {
+                    modifyProfile()
+                }
             }
         }
 
@@ -145,6 +149,7 @@ class ProfileEditViewModel
                     nickname = currentUiState.nickname,
                     commitmentMessage = currentUiState.commitmentMessage,
                 ).onSuccess {
+                    setSideEffect(ProfileEditContract.ProfileEditSideEffect.NavigateToBack)
                 }.onFailure {
                     Timber.e(it,"[마이페이지] 프로필 정보 수정 실패")
                 }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditViewModel.kt
@@ -54,20 +54,12 @@ class ProfileEditViewModel
                     updateState(UpdateState(currentUiState.copy(nickname = event.nickname)))
                 }
 
-                ProfileEditContract.ProfileEditEvent.OnNicknameClick -> {
-                    updateState(UpdateState(currentUiState.copy(isNicknameBottomSheetVisible = true)))
-                }
-
                 ProfileEditContract.ProfileEditEvent.OnProfileImgClick -> {
                     updateState(UpdateState(currentUiState.copy(isProfileImgBottomSheetVisible = true)))
                 }
 
                 is ProfileEditContract.ProfileEditEvent.OnProfileImageSelect -> {
                     updateState(UpdateState(currentUiState.copy(selectedProfileImageKey = OnboardingConstants.PROFILE_IMG_RES_IDS.indexOf(event.imageRes) + 1)))
-                }
-
-                ProfileEditContract.ProfileEditEvent.OnNicknameBottomSheetDismissRequest -> {
-                    updateState(UpdateState(currentUiState.copy(isNicknameBottomSheetVisible = false)))
                 }
 
                 ProfileEditContract.ProfileEditEvent.OnProfileImgBottomSheetDismissRequest -> {
@@ -101,23 +93,6 @@ class ProfileEditViewModel
         ): ProfileEditContract.ProfileEditState {
             return when (reduce) {
                 is ProfileEditContract.ProfileEditReduce.UpdateState -> reduce.state
-            }
-        }
-
-        private fun convertResIdToKey(
-            @DrawableRes imgResId: Int,
-        ): Int {
-            return when (imgResId) {
-                DEFAULT_PROFILE_IMG_RES_ID -> 0
-
-                else -> {
-                    val index = OnboardingConstants.PROFILE_IMG_RES_IDS.indexOf(imgResId)
-                    if (index != -1) {
-                        index + 1
-                    } else {
-                        0
-                    }
-                }
             }
         }
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/profileedit/ProfileEditViewModel.kt
@@ -23,6 +23,11 @@ class ProfileEditViewModel
     ) : BaseViewModel<ProfileEditContract.ProfileEditEvent, ProfileEditContract.ProfileEditState, ProfileEditContract.ProfileEditReduce, ProfileEditContract.ProfileEditSideEffect>(
             savedStateHandle = savedStateHandle,
         ) {
+
+        init {
+            loadInitialData()
+        }
+
         override fun createInitialState(savedState: Parcelable?): ProfileEditContract.ProfileEditState {
             return savedState as? ProfileEditContract.ProfileEditState ?: ProfileEditContract.ProfileEditState()
         }
@@ -57,8 +62,8 @@ class ProfileEditViewModel
                     updateState(UpdateState(currentUiState.copy(isProfileImgBottomSheetVisible = true)))
                 }
 
-                is ProfileEditContract.ProfileEditEvent.OnProfileImgSelect -> {
-                    updateState(UpdateState(currentUiState.copy(selectedImg = event.imgRes)))
+                is ProfileEditContract.ProfileEditEvent.OnProfileImageSelect -> {
+                    updateState(UpdateState(currentUiState.copy(selectedProfileImageKey = OnboardingConstants.PROFILE_IMG_RES_IDS.indexOf(event.imageRes) + 1)))
                 }
 
                 ProfileEditContract.ProfileEditEvent.OnNicknameBottomSheetDismissRequest -> {
@@ -77,7 +82,7 @@ class ProfileEditViewModel
                     updateState(
                         UpdateState(
                             currentUiState.copy(
-                                profileImg = currentUiState.selectedImg,
+                                profileImageResId = currentUiState.selectedProfileImageResId,
                                 isProfileImgBottomSheetVisible = false,
                             ),
                         ),
@@ -116,7 +121,17 @@ class ProfileEditViewModel
             viewModelScope.launch {
                 userRepository.getProfileInformation()
                     .onSuccess { profileInformation ->
-
+                        updateState(
+                            UpdateState(
+                                currentUiState.copy(
+                                    profileImageResId = OnboardingConstants.PROFILE_IMG_RES_IDS.getOrNull(profileInformation.profileImageKey - 1)
+                                        ?: DEFAULT_PROFILE_IMG_RES_ID,
+                                    selectedProfileImageKey = profileInformation.profileImageKey,
+                                    nickname = profileInformation.nickname,
+                                    commitmentMessage = profileInformation.commitmentMessage,
+                                ),
+                            ),
+                        )
                     }.onFailure {
                         Timber.e(it, "[마이페이지] 프로필 정보 불러오기 실패")
                     }
@@ -126,7 +141,7 @@ class ProfileEditViewModel
         private fun modifyProfile() {
             viewModelScope.launch {
                 userRepository.modifyProfileInformation(
-                    profileImageKey = convertResIdToKey(currentUiState.selectedImg),
+                    profileImageKey = currentUiState.selectedProfileImageKey,
                     nickname = currentUiState.nickname,
                     commitmentMessage = currentUiState.commitmentMessage,
                 ).onSuccess {

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/TimerTodoRoute.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/TimerTodoRoute.kt
@@ -65,6 +65,7 @@ fun TimerTodoRoute(
                 onTimeConfirmButtonClick = { startTime -> viewModel.setEvent(TimerTodoEvent.OnTimeConfirmButtonClick(startTime)) },
                 onTimePickerBottomSheetDismissRequest = { viewModel.setEvent(TimerTodoEvent.OnTimePickerBottomSheetDismissRequest) },
                 onTimePickerBottomSheetShowRequest = { viewModel.setEvent(TimerTodoEvent.OnTimePickerBottomSheetShowRequest) },
+                onTimePickerBottomSheetClearButtonClick = { viewModel.setEvent(TimerTodoEvent.OnTimePickerBottomSheetClearButtonClick) },
                 onTodoTextChange = { todoText -> viewModel.setEvent(TimerTodoEvent.OnTodoTextChange(todoText)) },
             )
 

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/TimerTodoScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/TimerTodoScreen.kt
@@ -44,6 +44,7 @@ import java.time.LocalTime
 fun TimerTodoScreen(
     uiState: TimerTodoContract.TimerTodoState,
     timeOptionIndex: Int,
+    onTimePickerBottomSheetClearButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
     onBackIconClick: () -> Unit = {},
     onExitBtnClick: () -> Unit = {},
@@ -124,7 +125,8 @@ fun TimerTodoScreen(
             onDismissRequest = onTimePickerBottomSheetDismissRequest,
             onCancleButtonClick = onTimePickerBottomSheetDismissRequest,
             onConfirmButtonClick = onTimeConfirmButtonClick,
-            initialTime = uiState.selectedStartTime ?: LocalTime.of(12, 0),
+            onClearButtonClick = onTimePickerBottomSheetClearButtonClick,
+            initialTime = uiState.selectedStartTime ?: LocalTime.of(12, 0)
         )
     }
 }
@@ -312,6 +314,6 @@ private fun TimerTodoScreenPreview() {
                 categories = exampleCategories,
                 flatList = flatList,
             )
-        TimerTodoScreen(uiState = previewState, timeOptionIndex = 0)
+        TimerTodoScreen(uiState = previewState, timeOptionIndex = 0, onTimePickerBottomSheetClearButtonClick = {})
     }
 }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/TimerTodoViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/TimerTodoViewModel.kt
@@ -113,6 +113,11 @@ class TimerTodoViewModel
                     updateState(UpdateTimePickerBottomSheetState(isTimePickerBottomSheetVisible = true))
                 }
 
+                TimerTodoEvent.OnTimePickerBottomSheetClearButtonClick -> {
+                    updateState(UpdateSelectedStartTime(null))
+                    updateState(UpdateTimePickerBottomSheetState(isTimePickerBottomSheetVisible = false))
+                }
+
                 is TimerTodoEvent.OnTodoTextChange -> {
                     updateState(UpdateTodoText(event.todoText))
                 }

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/contract/TimerTodoContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/timer/todo/contract/TimerTodoContract.kt
@@ -42,6 +42,8 @@ class TimerTodoContract {
 
         data object OnTimePickerBottomSheetShowRequest : TimerTodoEvent
 
+        data object OnTimePickerBottomSheetClearButtonClick : TimerTodoEvent
+
         data object OnRestartTimerBtnClick : TimerTodoEvent
 
         data object OnExitBtnClick : TimerTodoEvent

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoContract.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoContract.kt
@@ -66,6 +66,8 @@ class TodoContract {
 
         data object OnTimePickerBottomSheetDismissRequest : TodoEvent
 
+        data object OnTimePickerBottomSheetClearButtonClick : TodoEvent
+
         data object OnAddTodoBottomSheetDismissRequest : TodoEvent
 
         data object OnTimePickerBottomSheetShowRequest : TodoEvent

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoRoute.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoRoute.kt
@@ -70,6 +70,9 @@ fun TodoRoute(
         onTimePickerBottomSheetDismissRequest = {
             viewModel.setEvent(TodoEvent.OnTimePickerBottomSheetDismissRequest)
         },
+        onTimePickerBottomSheetClearButtonClick = {
+            viewModel.setEvent(TodoEvent.OnTimePickerBottomSheetClearButtonClick)
+        },
         onAddTodoBottomSheetDismissRequest = {
             viewModel.setEvent(TodoEvent.OnAddTodoBottomSheetDismissRequest)
         },

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoScreen.kt
@@ -126,6 +126,7 @@ fun TodoScreen(
     onAddTodoBottomSheetDismissRequest: () -> Unit,
     onTodoSettingBottomSheetDismissRequest: () -> Unit,
     onTimePickerBottomSheetShowRequest: () -> Unit,
+    onTimePickerBottomSheetClearButtonClick: () -> Unit,
     onMonthlyCalendarBottomSheetDismissRequest: () -> Unit,
     onDateSaveButtonClick: () -> Unit,
     onMonthlyDateSelect: (LocalDate) -> Unit,
@@ -361,6 +362,7 @@ fun TodoScreen(
             onCancleButtonClick = onTimePickerBottomSheetDismissRequest,
             onConfirmButtonClick = onTimeConfirmButtonClick,
             initialTime = selectedStartTime ?: LocalTime.of(12, 0),
+            onClearButtonClick = {}
         )
         CommitmentBottomSheet(
             isBottomSheetVisible = isCommitmentBottomSheetVisible,
@@ -848,6 +850,7 @@ fun TodoScreenPreview() {
         onTimePickerBottomSheetDismissRequest = {},
         onAddTodoBottomSheetDismissRequest = {},
         onTimePickerBottomSheetShowRequest = {},
+        onTimePickerBottomSheetClearButtonClick = {},
         onTodoTextChange = {},
         onCategoryChipClick = {},
         textFieldCommitmentMessage = "",

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoScreen.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoScreen.kt
@@ -362,7 +362,7 @@ fun TodoScreen(
             onCancleButtonClick = onTimePickerBottomSheetDismissRequest,
             onConfirmButtonClick = onTimeConfirmButtonClick,
             initialTime = selectedStartTime ?: LocalTime.of(12, 0),
-            onClearButtonClick = {}
+            onClearButtonClick = onTimePickerBottomSheetClearButtonClick
         )
         CommitmentBottomSheet(
             isBottomSheetVisible = isCommitmentBottomSheetVisible,

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoViewModel.kt
@@ -215,6 +215,17 @@ class TodoViewModel
                     }
                 }
 
+                TodoEvent.OnTimePickerBottomSheetClearButtonClick -> {
+                    updateState(
+                        UpdateTodoState(
+                            currentUiState.copy(
+                                selectedStartTime = null,
+                                isTimePickerBottomSheetVisible = false
+                            )
+                        )
+                    )
+                }
+
                 TodoEvent.OnAddTodoBottomSheetDismissRequest -> {
                     if (currentUiState.todoText.isNotBlank()) {
                         addTodo(

--- a/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoViewModel.kt
@@ -216,14 +216,68 @@ class TodoViewModel
                 }
 
                 TodoEvent.OnTimePickerBottomSheetClearButtonClick -> {
-                    updateState(
-                        UpdateTodoState(
-                            currentUiState.copy(
-                                selectedStartTime = null,
-                                isTimePickerBottomSheetVisible = false
-                            )
+                    if (currentUiState.isEditMode) {
+                        val prevStartTime = currentUiState.selectedStartTime
+                        val selectedTodoId = currentUiState.selectedTodoItem!!.todo.todoId
+                        viewModelScope.launch {
+                            todoRepository.modifyTodoTime(
+                                todoId = selectedTodoId.toLong(),
+                                startTime = null,
+                            ).onSuccess {
+                                val updatedCategories =
+                                    currentUiState.categories.map { category ->
+                                        category.copy(
+                                            todos =
+                                                category.todos.map {
+                                                    if (it.todoId == selectedTodoId) {
+                                                        it.copy(startTime = null)
+                                                    } else {
+                                                        it
+                                                    }
+                                                },
+                                        )
+                                    }
+                                updateState(
+                                    UpdateTodoState(
+                                        currentUiState.copy(
+                                            selectedStartTime = null,
+                                            categories = updatedCategories,
+                                            flatList = updatedCategories.toFlatList(),
+                                            isTimePickerBottomSheetVisible = false,
+                                            isTodoSettingBottomSheetVisible = true,
+                                            selectedTodoItem =
+                                                currentUiState.selectedTodoItem!!.copy(
+                                                    todo =
+                                                        currentUiState.selectedTodoItem!!.todo.copy(
+                                                            startTime = null,
+                                                        ),
+                                                ),
+                                        ),
+                                    ),
+                                )
+                            }.onFailure {
+                                updateState(
+                                    UpdateTodoState(
+                                        currentUiState.copy(
+                                            selectedStartTime = prevStartTime,
+                                            isTimePickerBottomSheetVisible = false,
+                                            isTodoSettingBottomSheetVisible = true,
+                                        ),
+                                    ),
+                                )
+                            }
+                        }
+                    } else {
+                        updateState(
+                            UpdateTodoState(
+                                currentUiState.copy(
+                                    selectedStartTime = null,
+                                    isAddTodoBottomSheetVisible = true,
+                                    isTimePickerBottomSheetVisible = false,
+                                ),
+                            ),
                         )
-                    )
+                    }
                 }
 
                 TodoEvent.OnAddTodoBottomSheetDismissRequest -> {
@@ -262,6 +316,7 @@ class TodoViewModel
                             currentUiState.copy(
                                 selectedCategory = event.category,
                                 isAddTodoBottomSheetVisible = true,
+                                isEditMode = false
                             ),
                         ),
                     )


### PR DESCRIPTION
## Related issue 🛠

- closed #86 

## Work Description ✏️
- [x] 단순 텍스트 입력의 경우 인라인 편집 방식으로 변경하여 사용자 인터랙션 뎁스를 축소
- [x] 프로필 수정 화면에서 저장하기 버튼을 추가해 데이터 변경(API 호출) 시점을 사용자가 인지할 수 있도록 개선
- [x] 시간 설정 바텀시트의 왼쪽 상단에 시간 초기화 버튼 구현

## Screenshot 📸
<table width="100%">
<tr>
<td align="center" valign="top">
<img src="https://github.com/user-attachments/assets/54ec7b7d-1d85-4ea5-bfd2-8bfc7f4e636e" width="60%" />
</td>
<td align="center" valign="top">
<img src="https://github.com/user-attachments/assets/df6c6f5e-1886-47f0-a911-d98f909e7e29" width="60%" />
</td>
</tr>
<tr>
<td align="center">시간 설정 초기화 버튼</td>
<td align="center">인라인 닉네임 편집 및 저장하기 버튼</td>
</tr>
</table>
