### PR TITLE
[Fix] 빈 문자열로 할 일 수정 시 상호작용이 불가능한 이슈 대응

### DIFF
--- a/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoViewModel.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/ui/todo/TodoViewModel.kt
@@ -573,6 +573,15 @@ class TodoViewModel
                             )
                         }.onFailure {
                             Timber.d("투두 이름 변경 실패")
+                            updateState(
+                                UpdateTodoState(
+                                    currentUiState.copy(
+                                        selectedTodoItem = null,
+                                        selectedCategory = null,
+                                        isEditTodoNameBottomSheetVisible = false,
+                                    ),
+                                ),
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
## Related issue 🛠

- closed #92 

## Work Description ✏️

- 빈 문자열로 할 일 수정이 실패했을 때 상태 업데이트

## Uncompleted Tasks 😅

- [ ] 빈 문자열로 할 일 수정이 실패한다는 피드백을 제공할 필요가 있어보임