### PR TITLE
[Fix] 웹뷰를 통한 카카오 로그인 버그 해결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data
                     android:host="oauth"
-                    android:scheme="${KAKAO_NATIVE_APP_KEY_MANIFEST}" />
+                    android:scheme="kakao${KAKAO_NATIVE_APP_KEY_MANIFEST}" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="oauth"
+                    android:scheme="${KAKAO_NATIVE_APP_KEY_MANIFEST}" />
+            </intent-filter>
+        </activity>
 
         <receiver android:name=".presentation.common.observer.ScreenStateReceiver" />
     </application>


### PR DESCRIPTION
## Related issue 🛠

- closed #94

## Work Description ✏️

- 카카오톡 앱이 설치되지 않은 환경에서 웹뷰(Browser)를 통한 카카오 로그인 시, 서비스 동의 후 '계속하기' 버튼을 눌러도 앱으로 리다이렉트(Redirect)되지 않고 브라우저에 머물러 있는 현상을 확인
- "동의하고 계속하기" 이후 Kakao 서버가 kakao앱키://oauth?code=...로 리다이렉트하는데, AuthCodeHandlerActivity가 없으면 Android가 이 Intent를 처리할 앱을 못 찾아서 콜백이 영원히 오지 않는데 이 AuthCodeHandlerActivity가 Manifest 파일에서 누락되어 있었음