### PR TITLE
[Fix] 토큰 재발급 관련 현상 수정

### DIFF
--- a/app/src/main/java/org/android/bbangzip/data/auth/interceptor/AuthEventManager.kt
+++ b/app/src/main/java/org/android/bbangzip/data/auth/interceptor/AuthEventManager.kt
@@ -5,7 +5,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class AuthEventManager
     @Inject
     constructor() {

--- a/app/src/main/java/org/android/bbangzip/data/auth/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/android/bbangzip/data/auth/interceptor/AuthInterceptor.kt
@@ -3,6 +3,7 @@ package org.android.bbangzip.data.auth.interceptor
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -44,13 +45,19 @@ class AuthInterceptor
                 }
 
             val response = chain.proceed(authRequest)
+            val url = BuildConfig.BASE_URL.toHttpUrl().newBuilder()
+                .addPathSegment(ApiConstants.API) // "api"
+                .addPathSegments(ApiConstants.VERSIONS) // "v1"
+                .addPathSegment(ApiConstants.AUTH)     // "auth"
+                .addPathSegment(ApiConstants.REISSUE)  // "reissue"
+                .build()
 
             when (response.code) {
                 EXPIRE_TOKEN_CODE -> {
                     response.close()
                     val refreshTokenRequest =
-                        originalRequest.newBuilder().get()
-                            .url("${BuildConfig.BASE_URL}${ApiConstants.VERSIONS}/${ApiConstants.AUTH}/${ApiConstants.REISSUE}")
+                        originalRequest.newBuilder()
+                            .url(url)
                             .post("".toRequestBody())
                             .addHeader(AUTHORIZATION, refreshToken ?: "")
                             .build()

--- a/app/src/main/java/org/android/bbangzip/data/auth/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/org/android/bbangzip/data/auth/interceptor/AuthInterceptor.kt
@@ -99,6 +99,6 @@ class AuthInterceptor
         companion object {
             const val AUTHORIZATION = "Authorization"
             const val EXPIRE_TOKEN_CODE = 401
-            const val BEARER = "Bearer"
+            const val BEARER = "Bearer "
         }
     }


### PR DESCRIPTION
## Related issue 🛠

- closed #96 

## Work Description ✏️

- 잘못된 re-issue api endpoint 설정 수정
- 토큰 재발급 요청 시 Authorization 헤더의 문자열 생성 로직에서 Bearer 키워드와 accessToken 사이의 공백 추가
- 토큰 재발급 시 오류가 난다면 강제 로그아웃 진행
  - 구현이 되어있었으나 AuthEventManager가 Singleton으로 구현되어있지 않아 작동하지 않는 현상 수정

## To Reviewers 📢
이번 PR에서는 토큰 재발급 실패 시 유저가 앱 내에서 아무런 동작도 할 수 없는 상태에 빠지는 것을 방지하고자 강제 로그아웃 및 카카오 로그인 화면 전환 로직을 추가했습니다.

원래는 Refresh Token 만료 시점에만 해당 로직이 동작하도록 하려했으나, 현재 서버 응답 구조상 RT 만료에 대한 에러 코드가 별도로 분기되어 있지 않은 것을 확인했습니다. 따라서 Reissue API 호출 시 발생하는 모든 오류에 대해 통합적으로 세션 만료 처리를 하도록 구현했습니다.