### PR TITLE
[Fix] 주간 캘린더 월 전환 구간 날짜 클릭 시 월 표시 오류 수정

### DIFF
--- a/app/src/main/java/org/android/bbangzip/presentation/common/component/calendar/BbangZipWeeklyCalendar.kt
+++ b/app/src/main/java/org/android/bbangzip/presentation/common/component/calendar/BbangZipWeeklyCalendar.kt
@@ -359,7 +359,7 @@ private fun DayCell(
 private fun LocalDate.getDisplayMonth(selectedDate: LocalDate): LocalDate {
     val lastDayOfWeek = this.plusDays(DAYS_IN_WEEK - 1L)
     return if (this.month != lastDayOfWeek.month) {
-        if (selectedDate.isAfter(this) && selectedDate.isBefore(lastDayOfWeek) && selectedDate.month == lastDayOfWeek.month) {
+        if (selectedDate.isAfter(this) && !selectedDate.isAfter(lastDayOfWeek) && selectedDate.month == lastDayOfWeek.month) {
             selectedDate
         } else {
             this


### PR DESCRIPTION
## Related issue 🛠

- closed #110 

## Work Description ✏️

- getDisplayMonth 함수에서 isBefore 함수로 인해서 마지막 날이 다음 달에 포함되지 않는 현상을 수정했습니다.